### PR TITLE
Functional rewrite

### DIFF
--- a/geometric_kernels/backends/jax/__init__.py
+++ b/geometric_kernels/backends/jax/__init__.py
@@ -1,0 +1,4 @@
+"""
+JAX specific code
+"""
+from geometric_kernels.backends.jax.sparsegpax import SparseGPaxGeometricKernel  # noqa

--- a/geometric_kernels/backends/jax/sparsegpax.py
+++ b/geometric_kernels/backends/jax/sparsegpax.py
@@ -1,0 +1,48 @@
+"""
+SparseGPax kernel wrapper
+"""
+from typing import NamedTuple
+
+import jax.numpy as jnp
+import sparsegpax.kernel
+
+from geometric_kernels.kernels import BaseGeometricKernel
+
+
+class GeometricKernelParameters(NamedTuple):
+    log_lengthscale: jnp.ndarray
+    log_nu: jnp.ndarray
+
+
+class SparseGPaxGeometricKernel(sparsegpax.kernel.AbstractKernel):
+    """
+    SparseGPax wrapper for `BaseGeometricKernel`
+    """
+
+    def __init__(self, kernel: BaseGeometricKernel):
+        self._kernel = kernel
+        self._init_params, self._state = kernel.init_params_and_state()
+
+    def init_params(self, key) -> GeometricKernelParameters:
+        params = self._init_params
+
+        return GeometricKernelParameters(
+            log_lengthscale=jnp.log(params["lengthscale"]), log_nu=jnp.log(params["nu"])
+        )
+
+    def matrix(self, params: GeometricKernelParameters, x1, x2):
+        kernel_params = {
+            "lengthscale": jnp.exp(params.log_lengthscale),
+            "nu": jnp.exp(params.log_nu),
+        }
+
+        return self._kernel.K(kernel_params, self._state, x1, x2)
+
+    def kernel(self, params: GeometricKernelParameters):
+        return self._kernel
+
+    def standard_spectral_measure(self, key, num_samples):
+        raise NotImplementedError("Spectral measure not implemented")
+
+    def spectral_weights(self, params, frequency):
+        raise NotImplementedError("Spectral weigths not implemented")

--- a/geometric_kernels/backends/pytorch/gpytorch.py
+++ b/geometric_kernels/backends/pytorch/gpytorch.py
@@ -2,6 +2,7 @@
 Pytorch kernel wrapper
 """
 import gpytorch
+import torch
 
 from geometric_kernels.kernels import BaseGeometricKernel
 from geometric_kernels.spaces.base import Space
@@ -19,14 +20,36 @@ class GPytorchGeometricKernel(gpytorch.kernels.Kernel):
 
         self._kernel = kernel
 
+        params, state = self._kernel.init_params_and_state()
+
+        self.state = state
+
+        self.lengthscale = torch.tensor(params["lengthscale"])
+        self.register_parameter(
+            name="raw_nu", parameter=torch.nn.Parameter(torch.tensor(params["nu"]))
+        )
+        self.register_constraint("raw_nu", gpytorch.constraints.Positive())
+
     @property
     def space(self) -> Space:
         """Alias to kernel Space"""
         return self._kernel.space
 
+    @property
+    def nu(self) -> torch.Tensor:
+        """A smoothness parameter"""
+        return self.raw_nu_constraint.transform(self.raw_nu)
+
+    @nu.setter
+    def nu(self, value):
+        value = torch.as_tensor(value).to(self.raw_nu)
+        self.initialize(raw_nu=self.raw_nu_constraint.inverse_transform(value))
+
     def forward(self, x1, x2, diag=False, last_dim_is_batch=False, **kwargs):
         """Eval kernel"""
         # TODO: check batching dimensions
+
+        params = dict(lengthscale=self.lengthscale, nu=self.nu)
         if diag:
-            return self._kernel.K_diag(x1, lengthscale=self.lengthscale)
-        return self._kernel.K(x1, x2, lengthscale=self.lengthscale)
+            return self._kernel.K_diag(params, self.state, x1)
+        return self._kernel.K(params, self.state, x1, x2)

--- a/geometric_kernels/jax.py
+++ b/geometric_kernels/jax.py
@@ -1,0 +1,3 @@
+import lab.jax  # noqa
+
+import geometric_kernels.lab_extras.jax  # noqa

--- a/geometric_kernels/kernels/base.py
+++ b/geometric_kernels/kernels/base.py
@@ -2,7 +2,7 @@
 Base class for geometric kernels
 """
 import abc
-from typing import Generic, TypeVar
+from typing import Generic, Mapping, Tuple, TypeVar
 
 import lab as B
 
@@ -30,11 +30,13 @@ class BaseGeometricKernel(abc.ABC, Generic[T]):
         return self._space
 
     @abc.abstractmethod
-    def init_params_and_state(self):
+    def init_params_and_state(
+        self,
+    ) -> Tuple[Mapping[str, B.Numeric], Mapping[str, B.Numeric]]:
         """
         Returns initial parameters and state of the kernels.
         params is a dict of trainable parameters of the kernel, such as lengthscale.
-        ntparams is a dict non-trainable parameters of the kernel.
+        state is a dict non-trainable parameters of the kernel.
         """
         raise NotImplementedError
 

--- a/geometric_kernels/kernels/base.py
+++ b/geometric_kernels/kernels/base.py
@@ -30,14 +30,23 @@ class BaseGeometricKernel(abc.ABC, Generic[T]):
         return self._space
 
     @abc.abstractmethod
-    def K(self, X, X2=None, **kwargs) -> B.Numeric:
+    def init_params_and_state(self):
+        """
+        Returns initial parameters and state of the kernels.
+        params is a dict of trainable parameters of the kernel, such as lengthscale.
+        ntparams is a dict non-trainable parameters of the kernel.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def K(self, params, state, X, X2=None, **kwargs) -> B.Numeric:
         """
         Returns pairwise covariance between `X` and `X2`.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def K_diag(self, X, **kwargs) -> B.Numeric:
+    def K_diag(self, params, state, X, **kwargs) -> B.Numeric:
         """
         Returns covariance between elements in `X`.
         """

--- a/geometric_kernels/kernels/base.py
+++ b/geometric_kernels/kernels/base.py
@@ -30,9 +30,7 @@ class BaseGeometricKernel(abc.ABC, Generic[T]):
         return self._space
 
     @abc.abstractmethod
-    def init_params_and_state(
-        self,
-    ) -> Tuple[Mapping[str, B.Numeric], Mapping[str, B.Numeric]]:
+    def init_params_and_state(self):
         """
         Returns initial parameters and state of the kernels.
         params is a dict of trainable parameters of the kernel, such as lengthscale.

--- a/geometric_kernels/kernels/base.py
+++ b/geometric_kernels/kernels/base.py
@@ -2,7 +2,7 @@
 Base class for geometric kernels
 """
 import abc
-from typing import Generic, Mapping, Tuple, TypeVar
+from typing import Generic, TypeVar
 
 import lab as B
 

--- a/geometric_kernels/kernels/geometric_kernels.py
+++ b/geometric_kernels/kernels/geometric_kernels.py
@@ -54,7 +54,8 @@ class MaternKarhunenLoeveKernel(BaseGeometricKernel):
         """
         Get initial params and state.
 
-        In this case, state is Laplacian eigenvalues and eigenfunctions.
+        In this case, state is Laplacian eigenvalues and eigenfunctions,
+        and params contains the lengthscale and smoothness parameter `nu`.
 
         :return: tuple(params, state)
         """

--- a/geometric_kernels/kernels/geometric_kernels.py
+++ b/geometric_kernels/kernels/geometric_kernels.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from geometric_kernels.eigenfunctions import Eigenfunctions
 from geometric_kernels.kernels import BaseGeometricKernel
+from geometric_kernels.lab_extras import from_numpy
 from geometric_kernels.spaces.base import DiscreteSpectrumSpace
 from geometric_kernels.utils import Optional
 
@@ -35,7 +36,6 @@ class MaternKarhunenLoeveKernel(BaseGeometricKernel):
     def __init__(
         self,
         space: DiscreteSpectrumSpace,
-        nu: float,
         num_eigenfunctions: int,
     ):
         r"""
@@ -48,19 +48,39 @@ class MaternKarhunenLoeveKernel(BaseGeometricKernel):
             in the summation.
         """
         super().__init__(space)
-        self.nu = nu
         self.num_eigenfunctions = num_eigenfunctions  # in code referred to as `M`.
 
-    def _spectrum(self, s: B.Numeric, lengthscale: B.Numeric) -> B.Numeric:
+    def init_params_and_state(self):
         """
-        Matern or RBF spectrum evaluated at `s`. Depends on the
-        `lengthscale` parameters.
+        Get initial params and state.
+
+        In this case, state is Laplacian eigenvalues and eigenfunctions.
+
+        :return: tuple(params, state)
         """
-        if self.nu == np.inf:
+        params = dict(lengthscale=1.0, nu=0.5)
+
+        eigenvalues_laplacian = self.space.get_eigenvalues(self.num_eigenfunctions)
+        eigenfunctions = self.space.get_eigenfunctions(self.num_eigenfunctions)
+
+        state = dict(
+            eigenvalues_laplacian=eigenvalues_laplacian, eigenfunctions=eigenfunctions
+        )
+
+        return params, state
+
+    def _spectrum(
+        self, s: B.Numeric, nu: B.Numeric, lengthscale: B.Numeric
+    ) -> B.Numeric:
+        """
+        Matern or RBF spectrum evaluated at `s`.
+        Depends on the `lengthscale` parameters.
+        """
+        if nu == np.inf:
             return B.exp(-(lengthscale ** 2) / 2.0 * (s ** 2))
-        elif self.nu > 0:
-            power = -self.nu - self.space.dimension / 2.0
-            base = 2.0 * self.nu / lengthscale ** 2 + (s ** 2)
+        elif nu > 0:
+            power = -nu - self.space.dimension / 2.0
+            base = 2.0 * nu / lengthscale ** 2 + from_numpy(nu, s ** 2)
             return base ** power
         else:
             raise NotImplementedError
@@ -72,30 +92,41 @@ class MaternKarhunenLoeveKernel(BaseGeometricKernel):
         eigenfunctions = self.space.get_eigenfunctions(self.num_eigenfunctions)
         return eigenfunctions
 
-    def eigenvalues(self, **parameters) -> B.Numeric:
+    def eigenvalues(self, params, state) -> B.Numeric:
         """
         Eigenvalues of the kernel.
 
         :return: [M, 1]
         """
-        assert "lengthscale" in parameters
-        eigenvalues_laplacian = self.space.get_eigenvalues(
-            self.num_eigenfunctions
-        )  # [M, 1]
+        assert "lengthscale" in params
+        assert "nu" in params
+
+        assert "eigenvalues_laplacian" in state
+
+        eigenvalues_laplacian = state["eigenvalues_laplacian"]  # [M, 1]
         return self._spectrum(
             eigenvalues_laplacian ** 0.5,
-            lengthscale=parameters["lengthscale"],
+            nu=params["nu"],
+            lengthscale=params["lengthscale"],
         )
 
     def K(
-        self, X: B.Numeric, X2: Optional[B.Numeric] = None, **parameters  # type: ignore
+        self, params, state, X: B.Numeric, X2: Optional[B.Numeric] = None, **kwargs  # type: ignore
     ) -> B.Numeric:
         """Compute the mesh kernel via Laplace eigendecomposition"""
-        weights = self.eigenvalues(**parameters)  # [M, 1]
-        Phi = self.eigenfunctions()
-        return Phi.weighted_outerproduct(weights, X, X2, **parameters)  # [N, N2]
+        assert "eigenfunctions" in state
+        assert "eigenvalues_laplacian" in state
 
-    def K_diag(self, X: B.Numeric, **parameters) -> B.Numeric:
-        weights = self.eigenvalues(**parameters)  # [M, 1]
-        Phi = self.eigenfunctions()
-        return Phi.weighted_outerproduct_diag(weights, X, **parameters)  # [N,]
+        weights = self.eigenvalues(params, state)  # [M, 1]
+        Phi = state["eigenfunctions"]
+
+        return Phi.weighted_outerproduct(weights, X, X2, **params)  # [N, N2]
+
+    def K_diag(self, params, state, X: B.Numeric, **kwargs) -> B.Numeric:
+        assert "eigenvalues_laplacian" in state
+        assert "eigenfunctions" in state
+
+        weights = self.eigenvalues(params, state)  # [M, 1]
+        Phi = state["eigenfunctions"]
+
+        return Phi.weighted_outerproduct_diag(weights, X, **params)  # [N,]

--- a/geometric_kernels/lab_extras/extras.py
+++ b/geometric_kernels/lab_extras/extras.py
@@ -16,7 +16,7 @@ def take_along_axis(a: B.Numeric, index: B.Numeric, axis: int = 0):
 
 @dispatch
 @abstract()
-def from_numpy(_: B.Numeric, b: Union[List, B.Numeric]):
+def from_numpy(_: B.Numeric, b: Union[List, B.Numeric, B.NPNumeric]):
     """
     Converts the array `b` to a tensor of the same backend as `a`
     """

--- a/geometric_kernels/lab_extras/jax/__init__.py
+++ b/geometric_kernels/lab_extras/jax/__init__.py
@@ -1,0 +1,1 @@
+from geometric_kernels.lab_extras.jax.extras import *

--- a/geometric_kernels/lab_extras/jax/extras.py
+++ b/geometric_kernels/lab_extras/jax/extras.py
@@ -1,0 +1,24 @@
+from typing import List
+
+import jax.numpy as jnp
+import lab as B
+from lab import dispatch
+from plum import Union
+
+_Numeric = Union[B.Number, B.JAXNumeric]
+
+
+@dispatch
+def take_along_axis(a: _Numeric, index: _Numeric, axis: int = 0) -> _Numeric:  # type: ignore
+    """
+    Gathers elements of `a` along `axis` at `index` locations.
+    """
+    return jnp.take_along_axis(a, index, axis=axis)
+
+
+@dispatch
+def from_numpy(_: B.JAXNumeric, b: Union[List, B.NPNumeric, B.Number, B.JAXNumeric]):  # type: ignore
+    """
+    Converts the array `b` to a tensor of the same backend as `a`
+    """
+    return jnp.array(b)

--- a/geometric_kernels/spaces/circle.py
+++ b/geometric_kernels/spaces/circle.py
@@ -130,7 +130,7 @@ class Circle(DiscreteSpectrumSpace, gs.geometry.hypersphere.Hypersphere):
         self,
         vector: B.Numeric,
         base_point: Optional[B.Numeric] = None,  # type: ignore
-        atol: float = gs.geometry.manifold.ATOL,
+        atol: float = gs.backend.atol,
     ) -> bool:
         """
         Check whether the `vector` is tangent at `base_point`.

--- a/geometric_kernels/spaces/mesh.py
+++ b/geometric_kernels/spaces/mesh.py
@@ -39,13 +39,11 @@ class ConvertEigenvectorsToEigenfunctions(Eigenfunctions):
         :return: [N, M]
         """
         indices = X
-        print(indices)
         if self.eigenvectors is None:
             # convert numpy eigenvectors to backend tensor
             self.eigenvectors = from_numpy(X, self.eigenvectors_np)
 
         Phi = take_along_axis(self.eigenvectors, indices, axis=0)
-        print(Phi)
         return Phi
 
     def num_eigenfunctions(self) -> int:

--- a/geometric_kernels/torch.py
+++ b/geometric_kernels/torch.py
@@ -1,0 +1,3 @@
+import lab.torch  # noqa
+
+import geometric_kernels.lab_extras.torch  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ torch
 gpflow
 tensorflow
 tensorflow-probability==0.14.0
-jax<=0.2.20
+jax
 jaxlib
 sparsegpax @ git+https://github.com/aterenin/SparseGPAX.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ torch
 gpflow
 tensorflow
 tensorflow-probability
+jax==0.2.20
+jaxlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ gpytorch
 torch
 gpflow
 tensorflow
-tensorflow-probability
+tensorflow-probability==0.14.0
 jax<=0.2.20
 jaxlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ torch
 gpflow
 tensorflow
 tensorflow-probability
-jax==0.2.20
+jax<=0.2.20
 jaxlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tensorflow
 tensorflow-probability==0.14.0
 jax<=0.2.20
 jaxlib
+sparsegpax @ git+https://github.com/aterenin/SparseGPAX.git

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "einops",
 ]
 
-with open("README.md", "r") as file:
+with open("README.md", "r", encoding="utf-8") as file:
     long_description = file.read()
 
 with open("VERSION", "r") as file:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,9 @@
+import lab.jax  # noqa
 import lab.numpy  # noqa
 import lab.tensorflow  # noqa
 import lab.torch  # noqa
 
+import geometric_kernels.lab_extras.jax  # noqa
 import geometric_kernels.lab_extras.numpy  # noqa
 import geometric_kernels.lab_extras.tensorflow  # noqa
 import geometric_kernels.lab_extras.torch  # noqa

--- a/tests/backends/jax/gpr_jax.py
+++ b/tests/backends/jax/gpr_jax.py
@@ -6,7 +6,6 @@ import meshzoo
 import numpy as np
 import polyscope as ps
 
-import geometric_kernels.jax  # noqa
 from geometric_kernels.backends.jax import SparseGPaxGeometricKernel
 from geometric_kernels.kernels import MaternKarhunenLoeveKernel
 from geometric_kernels.spaces import Mesh

--- a/tests/backends/jax/gpr_jax.py
+++ b/tests/backends/jax/gpr_jax.py
@@ -1,0 +1,83 @@
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+import meshzoo
+import numpy as np
+import polyscope as ps
+
+import geometric_kernels.jax  # noqa
+from geometric_kernels.backends.jax import SparseGPaxGeometricKernel
+from geometric_kernels.kernels import MaternKarhunenLoeveKernel
+from geometric_kernels.spaces import Mesh
+
+
+class GlobalRNG:
+    def __init__(self, seed: int = np.random.randint(2147483647)):
+        self.key = jax.random.PRNGKey(seed)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        (ret_key, self.key) = jr.split(self.key)
+        return ret_key
+
+
+rng = GlobalRNG()
+
+resolution = 40
+vertices, faces = meshzoo.icosa_sphere(resolution)
+mesh = Mesh(vertices, faces)
+
+nu = 1 / 2.0
+truncation_level = 20
+base_kernel = MaternKarhunenLoeveKernel(mesh, truncation_level)
+geometric_kernel = SparseGPaxGeometricKernel(base_kernel)
+
+init_params = geometric_kernel.init_params(next(rng))
+
+num_data = 25
+
+
+def get_data():
+    _X = jax.random.randint(
+        next(rng), minval=0, maxval=mesh.num_vertices, shape=(num_data, 1)
+    )
+    _K = geometric_kernel.matrix(init_params, _X, _X)
+    _y = jnp.linalg.cholesky(_K + jnp.eye(num_data) * 1e-6) @ jax.random.normal(
+        next(rng), (num_data,)
+    )
+    return _X, _y
+
+
+X, y = get_data()
+
+X_test = jnp.arange(mesh.num_vertices).reshape(mesh.num_vertices, 1)
+
+Kxx = geometric_kernel.matrix(init_params, X, X) + jnp.eye(num_data) * 1e-6
+Lxx, _ = jsp.linalg.cho_factor(Kxx, lower=True)
+Lxx_y = jsp.linalg.cho_solve((Lxx, True), y)
+
+Kxt = geometric_kernel.matrix(init_params, X, X_test)
+Lxx_Kxt = jsp.linalg.cho_solve((Lxx, True), Kxt)
+
+m = jnp.dot(Lxx_Kxt.T, Lxx_y)  # Ktx @ Kxx^{-1} ^ Y
+
+Ktt = geometric_kernel.matrix(init_params, X_test, X_test)
+
+Ktt_posterior = Ktt - Lxx_Kxt.T @ Lxx_Kxt  # Ktt - Ktx @ Kxx^{-1} @ Kxt
+v = jnp.diag(Ktt_posterior)
+
+print("grad", jax.jacfwd(geometric_kernel.matrix)(init_params, X, X))
+
+vertices_X = jnp.take_along_axis(vertices, X.reshape(-1, 1), axis=0)
+
+ps.init()
+ps_cloud = ps.register_point_cloud("my points", vertices_X)
+ps_cloud.add_scalar_quantity("data", y.flatten())
+
+my_mesh = ps.register_surface_mesh("my mesh", vertices, faces, smooth_shade=True)
+my_mesh.add_scalar_quantity("mean", m.squeeze(), enabled=True)
+my_mesh.add_scalar_quantity("variance", v.squeeze(), enabled=True)
+ps.show()

--- a/tests/backends/pytorch/gpr_torch.py
+++ b/tests/backends/pytorch/gpr_torch.py
@@ -16,7 +16,7 @@ class ExactGPModel(gpytorch.models.ExactGP):
         self.mean_module = gpytorch.means.ZeroMean()
         self.covar_module = kernel
 
-    def forward(self, x):  # pylint: disable=arguments-differq
+    def forward(self, x):  # pylint: disable=arguments-differ
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)
         return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
@@ -35,7 +35,7 @@ num_data = 25
 
 
 def get_data():
-    _X = torch.tensor(np.random.randint(mesh.num_vertices, size=(num_data,)))
+    _X = torch.tensor(np.random.randint(mesh.num_vertices, size=(num_data,))).int()
     _K = geometric_kernel(_X).numpy()
     _y = torch.tensor(
         np.linalg.cholesky(_K + np.eye(num_data) * 1e-6) @ np.random.randn(num_data)

--- a/tests/backends/tensorflow/test_gpr.py
+++ b/tests/backends/tensorflow/test_gpr.py
@@ -1,5 +1,4 @@
 import gpflow
-import meshzoo
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -7,6 +6,11 @@ import tensorflow as tf
 from geometric_kernels.backends.tensorflow import GPflowGeometricKernel
 from geometric_kernels.kernels import MaternKarhunenLoeveKernel
 from geometric_kernels.spaces import Mesh
+
+try:  # a temporary workaround for Python<3.7
+    import meshzoo
+except SyntaxError:
+    pass
 
 
 class DefaultFloatZero(gpflow.mean_functions.Constant):
@@ -32,7 +36,7 @@ class DefaultFloatZero(gpflow.mean_functions.Constant):
 
 
 # TODO(VD) This needs fixing!
-@pytest.mark.skip()
+@pytest.mark.skipif()
 def test_gpflow_integration():
     """
     Build GPflow GPR model with a Mesh Geometric Kernel.

--- a/tests/kernels/test_matern_karhunenloeve_kernel.py
+++ b/tests/kernels/test_matern_karhunenloeve_kernel.py
@@ -7,18 +7,21 @@ from geometric_kernels.kernels import MaternKarhunenLoeveKernel
 from geometric_kernels.spaces import Mesh
 
 _TRUNCATION_LEVEL = 10
-_NU = 1 / 2.0
+_NU = np.r_[1 / 2.0]
 
 
 @fixture(name="kernel")
 def fixture_mesh_kernel() -> MaternKarhunenLoeveKernel:
     filename = Path(__file__).parent / "../teddy.obj"
     mesh = Mesh.load_mesh(str(filename))
-    return MaternKarhunenLoeveKernel(mesh, _NU, _TRUNCATION_LEVEL)
+    return MaternKarhunenLoeveKernel(mesh, _TRUNCATION_LEVEL)
 
 
 def test_eigenvalues(kernel: MaternKarhunenLoeveKernel):
-    assert kernel.eigenvalues(lengthscale=np.r_[0.81]).shape == (_TRUNCATION_LEVEL, 1)
+    params = dict(lengthscale=np.r_[0.81], nu=_NU)
+    _, state = kernel.init_params_and_state()
+
+    assert kernel.eigenvalues(params, state).shape == (_TRUNCATION_LEVEL, 1)
 
 
 def test_eigenfunctions(kernel: MaternKarhunenLoeveKernel):
@@ -30,15 +33,19 @@ def test_eigenfunctions(kernel: MaternKarhunenLoeveKernel):
 
 
 def test_K_shapes(kernel: MaternKarhunenLoeveKernel):
+    params, state = kernel.init_params_and_state()
+    params["nu"] = _NU
+    params["lengthscale"] = np.r_[0.99]
+
     N1, N2 = 11, 13
     X = np.random.randint(low=0, high=kernel.space.num_vertices, size=(N1, 1))
     X2 = np.random.randint(low=0, high=kernel.space.num_vertices, size=(N2, 1))
 
-    K = kernel.K(X, None, lengthscale=np.r_[0.99])
+    K = kernel.K(params, state, X, None)
     assert K.shape == (N1, N1)
 
-    K = kernel.K(X, X2, lengthscale=np.r_[0.99])
+    K = kernel.K(params, state, X, X2)
     assert K.shape == (N1, N2)
 
-    K = kernel.K_diag(X, lengthscale=np.r_[0.99])
+    K = kernel.K_diag(params, state, X)
     assert K.shape == (N1,)

--- a/tests/spaces/test_circle.py
+++ b/tests/spaces/test_circle.py
@@ -158,8 +158,12 @@ def test_equivalence_kernel(nu, decimal, inputs):
     inputs, inputs2 = inputs
     # Spectral kernel
     circle = Circle()
-    kernel = MaternKarhunenLoeveKernel(circle, nu, num_eigenfunctions=101)
-    K_actual = B.to_numpy(kernel.K(inputs, inputs2, lengthscale=np.r_[1.0]))
+    kernel = MaternKarhunenLoeveKernel(circle, num_eigenfunctions=101)
+    params, state = kernel.init_params_and_state()
+    params["nu"] = np.r_[nu]
+    params["lengthscale"] = np.r_[1.0]
+
+    K_actual = B.to_numpy(kernel.K(params, state, inputs, inputs2))
 
     # Kernel by summing over all distances
     geodesic = inputs[:, None, :] - inputs2[None, :, :]  # [N, N2, 1]


### PR DESCRIPTION
Introduce `params` and `state` for the kernel.
`params` is a dict of `lengthscale` and `nu`, while `state` represents non-trainable parameters of the kernel (e.g. for `MaternKarhunenLoeveKernel` that would be `laplacian_eigenvalues` and `eigenfunctions`). 

Also, add a `jax` example with the `SparseGPax`  interface (see [the repo](https://github.com/aterenin/SparseGPAX)).