### PR TITLE
Fix the `backend` (`lab`) and `plum-dispatch` versions for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from setuptools import find_namespace_packages, setup
 requirements = [
     "numpy>=1.16",
     "scipy>=1.3",
-    "plum-dispatch>=1",
-    "backends>=1.4.3",
+    "plum-dispatch==1.7.4",
+    "backends==1.4.32",
     "potpourri3d",
     "robust_laplacian",
     "meshzoo",


### PR DESCRIPTION
As per https://github.com/wesselb/lab/issues/6, the newer lab version require some modifications to run