### PR TITLE
Fix issue #93

### DIFF
--- a/notebooks/mesh_gpr_gpflow.ipynb
+++ b/notebooks/mesh_gpr_gpflow.ipynb
@@ -15437,7 +15437,7 @@
    "source": [
     "nu = 1 / 2.0\n",
     "truncation_level = 20\n",
-    "base_kernel = MaternKarhunenLoeveKernel(mesh, nu, truncation_level)\n",
+    "base_kernel = MaternKarhunenLoeveKernel(mesh, truncation_level)\n",
     "kernel = GPflowGeometricKernel(base_kernel)\n",
     "num_data = 10  # n\n",
     "\n",


### PR DESCRIPTION
Remove old-style `nu` from instantiation of the
`MaternKarhunenLoeveKernel` in the `mesh_gpr_gpflow.ipynb` example notebook.

fix #93 