### PR TITLE
Pin orbax-checkpoint version for Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,5 +105,6 @@ dev = [
   'jaxlib',
   'jaxtyping',
   'optax',
-  'gpjax>=0.12.2; python_version >= "3.10"',  # gpjax requires python >= 3.10.
+  'gpjax>=0.12.2',
+  'orbax-checkpoint==0.11.32; platform_system == "Windows"',   # newer version depends on uvloop, unavailable in windows
 ]


### PR DESCRIPTION
Compatibility issue with a newer gpjax:
```
`uvloop` (v0.22.1) was included because `geometric-kernels:dev`
        (v0.4.2) depends on `gpjax` (v0.13.6) which depends on `flax`
        (v0.12.3) which depends on `orbax-checkpoint` (v0.11.33) which depends
        on `uvloop`
```
but
```
RuntimeError: uvloop does not support Windows at the moment
```